### PR TITLE
Use quotes for TIM1 header include

### DIFF
--- a/Core/Src/TIM1_Init.c
+++ b/Core/Src/TIM1_Init.c
@@ -1,4 +1,4 @@
-#include <TIM1_Init.h>
+#include "TIM1_Init.h"
 #include "main.h"
 
 


### PR DESCRIPTION
## Summary
- include TIM1_Init header using quotes

## Testing
- `gcc -c Core/Src/TIM1_Init.c -I Core/Inc -I Drivers/STM32G4xx_HAL_Driver/Inc -I Drivers/CMSIS/Device/ST/STM32G4xx/Include -I Drivers/CMSIS/Include -DSTM32G431xx -o /tmp/TIM1_Init.o`


------
https://chatgpt.com/codex/tasks/task_e_68ac324e5c0883319cc55dd12978d626