### PR TITLE
Add debug assertions for invalid SVPWM sectors

### DIFF
--- a/Core/Src/SVPWM.c
+++ b/Core/Src/SVPWM.c
@@ -24,6 +24,7 @@
 #include "util.h" // Include ASW util header file
 #include <math.h> // Include math library for cos() and sin()
 #include "debug.h" // Include ASW debug header file
+#include <assert.h>
 
 
 
@@ -94,6 +95,9 @@ int svpwm_calculate(SvpwmData* data) {
         T1 = (T_VAL / VBus) * (-Sqrt3Vb);
         T2 = (T_VAL / (2.0f * VBus)) * (3.0f * Va + Sqrt3Vb);
         break;
+    default:
+        assert(false);
+        break;
     }
 
 
@@ -144,6 +148,9 @@ int svpwm_calculate(SvpwmData* data) {
         ChA = T0 * 0.5f;
         ChC = ChA + T2;
         ChB = ChC + T1;
+        break;
+    default:
+        assert(false);
         break;
     }
 


### PR DESCRIPTION
## Summary
- Ensure invalid sectors trigger assertions during development builds
- Include assert header for SVPWM implementation

## Testing
- `gcc -c Core/Src/SVPWM.c -I Core/Inc -I Drivers/CMSIS/Include -I Drivers/STM32G4xx_HAL_Driver/Inc -I Drivers/CMSIS/Device/ST/STM32G4xx/Include -DSTM32G431xx -DUSE_HAL_DRIVER`


------
https://chatgpt.com/codex/tasks/task_e_68ac31d65a588331baf24f094c3e30e5